### PR TITLE
Do not mark from_raw_unchecked as unsafe

### DIFF
--- a/src/roman.rs
+++ b/src/roman.rs
@@ -61,7 +61,7 @@ impl Roman {
     /// it is.
     ///
     /// > Note: being "unprintable" is not memory unsafe and will not panic.
-    pub unsafe fn from_unchecked(n: i32) -> Roman {
+    pub fn from_unchecked(n: i32) -> Roman {
         Roman(n)
     }
 


### PR DESCRIPTION
This function has no memory safety issues; the only problem is that it
can potentially create numerals that are wildly out of range (i.e.
values that are far beyond the maximum printable value of 3999, or far
less than the minimum value of 1).

> Note: large values *are* printable (because the formatter will just
spit out M until the cows come home), while small values get "printed"
as a blank (since the ladder does not contain any values smaller than
1), and so neither of these cases represents a panic condition for our
to_string functions.