### PR TITLE
Restabilize

### DIFF
--- a/src/roman.rs
+++ b/src/roman.rs
@@ -104,18 +104,9 @@ impl str::FromStr for Roman {
     type Err = ParseRomanError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-
-        // This code is neat but only runs on nightly for now:
-        // RomanUnitIterator::new(s)
-        //     .sum::<Result<i32, ParseRomanError>>()
-        //     .and_then(|n| Roman::from(n).ok_or_else(|| ParseRomanError::out_of_range(n)))
-
-        let mut acc = 0;
-        for n in RomanUnitIterator::new(s) {
-            let n = n?;
-            acc += n;
-        }
-        Ok(Roman::from(acc).ok_or_else(|| ParseRomanError::out_of_range(acc))?)
+        RomanUnitIterator::new(s)
+            .sum::<Result<i32, ParseRomanError>>()
+            .and_then(|n| Roman::from(n).ok_or_else(|| ParseRomanError::out_of_range(n)))
     }
 }
 


### PR DESCRIPTION
Looks like the `sum()` call that did not exist in 1.15.1 is now a thing in 1.16.