### PR TITLE
Fix y4k bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvii"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["J/A <archer884@gmail.com>"]
 
 description = """

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 [![Crates.io](https://img.shields.io/crates/v/xvii.svg)](https://crates.io/crates/xvii)
 [![Build Status](https://travis-ci.org/archer884/xvii.svg?branch=master)](https://travis-ci.org/archer884/xvii)
 
-
 ...Pronounced any way you like, including "seventeen."
 
 This library provides parsing and formatting for Roman numerals. According to my (probably extremely suspect) benchmarks, this is the best-performing library of its kind available on crates.io (you know, as of St. Patrick's Day, 2017 when I did the tests), so you should definitely employ it in your high-availability NAAS (numerals-as-a-service) project.
 
 (Seriously, though, read the license--no warranties implied!)
+
+Also, if you have a high-availability NAAS project, you need to have your head examined. I don't know if that was clear when I originally wrote this readme, so I'm adding it now.
 
 ## Usage
 
@@ -26,9 +27,9 @@ There are several formatting options. `Roman` implements `Display`, which means 
 
 Regarding formatting, there is one gotcha regarding the formatting of `Roman` values created via `Roman::from_unchecked()`: values that are less than the minimum printable value will come out as empty strings, while values that are larger will simply look like `MMMMMMMMMMMMMMMXIV` or something like that.
 
-## Roadmap
+## Changelog
 
-I'm thinking of stealing that feature from the other library where you can use the `"{:x}"` or `"{:X}"` formatters to choose upper vs. lower case in formatting.
+* *v0.2.2* Upgrade parsing to use some kind of whacky state machine in order to permit numbers up to the commonly accepted ceiling of 4999, or MMMMCMXCIX, thereby avoiding a potential Y4K bug. Your thousand year reich is now safe with me.
 
 ## License
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ impl RomanError {
     pub fn out_of_range(n: i32) -> RomanError {
         RomanError {
             kind: RomanErrorKind::OutOfRange(n),
-            message: Cow::from("Value out of range (1...3999)"),
+            message: Cow::from("Value out of range (1...4999)"),
         }
     }
 }

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -53,7 +53,7 @@ impl Roman {
     /// cannot be appropriately formatted using the seven standard numerals.
     pub fn from(n: i32) -> Option<Roman> {
         match n {
-            n @ 1...3999 => Some(Roman(n)),
+            n @ 1...4999 => Some(Roman(n)),
             _ => None,
         }
     }
@@ -148,7 +148,18 @@ mod tests {
     }
 
     #[test]
-    fn max_value_equals_3999() {
+    fn mmmcmxcix_value_equals_3999() {
         assert_eq!("MMMCMXCIX", Roman(3999).to_string());
+    }
+
+    #[test]
+    fn max_value_equals_4999() {
+        assert_eq!("MMMMCMXCIX", Roman(4999).to_string());
+    }
+
+    #[test]
+    fn mmmmcmxcix_parses_as_4999() {
+        let result: Roman = "MMMMCMXCIX".parse().unwrap();
+        assert_eq!(4999, *result);
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,6 +1,53 @@
 use error::*;
 use std::str;
 
+/// Accumulates the value of a single numeral "unit."
+///
+/// qty represents the number of times the numeral has appeared in the unit, while num represents
+/// the numeric value of the numeral. Obviously, the final value of the unit is evaluated by
+/// multiplying these two.
+#[derive(Default)]
+struct Accumulator {
+    qty: i32,
+    val: i32,
+}
+
+impl Accumulator {
+    fn new(val: i32) -> Self {
+        Accumulator { qty: 1, val }
+    }
+
+    fn push(mut self, val: i32) -> PushResult {
+        use std::cmp::Ordering::*;
+
+        match self.val.cmp(&val) {
+            Equal => {
+                self.qty += 1;
+                PushResult::Partial(self)
+            }
+
+            Less => PushResult::Complete(val - self.value(), None),
+            Greater => PushResult::Complete(self.value(), Some(Accumulator::new(val)))
+        }
+    }
+
+    fn value(&self) -> i32 {
+        self.qty * self.val
+    }
+}
+
+/// The result of a push onto an accumulator.
+///
+/// Adding an additional instance of the original unit onto an accumulator emits a partial result
+/// because the accumulator may have an indefinite number of such instances. I, II, III, IIIIIII
+/// and so forth are all valid contents for an accumulator. However, changing the unit value
+/// will cause the accumulator to emit a complete result, signifying that a value should be
+/// produced by the iterator and a new accumulator created.
+enum PushResult {
+    Partial(Accumulator),
+    Complete(i32, Option<Accumulator>),
+}
+
 /// Iterates "units" of a Roman numeral.
 ///
 /// I have arbitrarily decided that a "unit" of a Roman numeral is any sequence
@@ -10,14 +57,14 @@ use std::str;
 /// by reading from left to right just once.
 pub struct RomanUnitIterator<'a> {
     bytes: str::Bytes<'a>,
-    last: Option<i32>,
+    acc: Option<Accumulator>,
 }
 
 impl<'a> RomanUnitIterator<'a> {
     pub fn new(s: &'a str) -> RomanUnitIterator<'a> {
         RomanUnitIterator {
             bytes: s.bytes(),
-            last: None,
+            acc: None,
         }
     }
 }
@@ -25,30 +72,44 @@ impl<'a> RomanUnitIterator<'a> {
 impl<'a> Iterator for RomanUnitIterator<'a> {
     type Item = Result<i32>;
 
+    // This appears to be deeply nested. I haven't the foggiest how that happened. >.>
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self.bytes.next() {
-                Some(x) => {
-                    let partial = match to_digit(x) {
-                        Ok(x) => x,
+                // If there are no more bytes left, just check for a leftover accumulator.
+                None => {
+                    return self.acc.take().map(|acc| Ok(acc.value()));
+                }
+
+                Some(u) => {
+                    // Return early if the next byte is invalid.
+                    let value = match to_digit(u) {
+                        Ok(u) => u,
                         Err(e) => return Some(Err(e)),
                     };
 
-                    match self.last {
-                        Some(prior) => {
-                            if partial > prior {
-                                self.last = None;
-                                return Some(Ok(partial - prior));
-                            } else {
-                                self.last = Some(partial + prior);
-                            }
+                    // Check for an existing accumulator.
+                    match self.acc.take() {
+                        // If we don't have one, make a new one with our new byte.
+                        None => {
+                            self.acc = Some(Accumulator::new(value));
                         }
 
-                        None => self.last = Some(partial),
+                        // Apply the new byte to any existing accumulator.
+                        Some(acc) => {
+                            match acc.push(value) {
+                                PushResult::Complete(n, acc) => {
+                                    self.acc = acc;
+                                    return Some(Ok(n));
+                                }
+
+                                PushResult::Partial(acc) => {
+                                    self.acc = Some(acc);
+                                }
+                            }
+                        }
                     }
                 }
-
-                None => return self.last.take().map(|x| Ok(x)),
             }
         }
     }


### PR DESCRIPTION
Apparently, 4999 is the largest accepted, commonly-expressible Roman numeral. The library previously had this value as 3999.

I attempted to just raise the hard-coded limit to 4999, but I discovered that even though the printing function was able to spit out the correct MCMCMCFUCK for 4999, the parsing function was apt to choke on it. The new parsing function has a little more abstraction thrown in and behaves more predictably. The overall strategy (based on numeral units, if you recall) is unchanged, and it still reads everything in one shot, left to right.