### PR TITLE
Don't use ASCII trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvii"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["J/A <archer884@gmail.com>"]
 
 description = """

--- a/benches/convert.rs
+++ b/benches/convert.rs
@@ -12,7 +12,7 @@ fn convert_from(b: &mut Bencher) {
     
     b.iter(|| {
         for value in &values {
-            test::black_box(value.parse::<Roman>());
+            test::black_box(value.parse::<Roman>().ok());
         }
     });
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -116,8 +116,7 @@ impl<'a> Iterator for RomanUnitIterator<'a> {
 }
 
 fn to_digit(c: u8) -> Result<i32> {
-    use std::ascii::AsciiExt;
-    match c.to_ascii_lowercase() {
+    match c | 32 {
         b'm' => Ok(1000),
         b'd' => Ok(500),
         b'c' => Ok(100),
@@ -134,6 +133,15 @@ fn to_digit(c: u8) -> Result<i32> {
 mod tests {
     use roman::Roman;
     use unit::RomanUnitIterator;
+
+    #[test]
+    fn to_digit_works() {
+        let digits = b"mDcLxVi";
+        assert!(digits.iter().all(|&d| super::to_digit(d).is_ok()));
+
+        let digits = b"aBeFgH";
+        assert!(digits.iter().all(|&d| super::to_digit(d).is_err()));
+    }
 
     #[test]
     fn i_equals_1() {


### PR DESCRIPTION
Rust 1.23 stabilizes the move of the ASCII trait methods from the trait to the pertinent types themselves. Of course, this is backward-incompatible (?!) I guess, with versions of the rust compiler
that don't have that feature in their version of the standard library (?!) (Hell if I know, shut up.), so in order to continue to support them, I would need to leave the trait in there but mark it with an
allow(unused) config flag...

Screw that.

We now or the byte with 32 in order to ensure that we're testing a "lowercase" value.