### PR TITLE
Replace `u16` with `NonZeroU16`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "xvii"
+# Do not forget bump the version before release. There were breaking changes.
 version = "0.4.0"
 authors = ["J/A <archer884@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let seventeen: Roman = "XVII".parse().unwrap();
 
 There are several formatting options. `Roman` implements `Display`, which means that it'll work fine with `println!("{}")` et al., but for maximum efficiency (stop laughing!) I also provide two other functions: `to_lowercase()` and `to_uppercase()`. These skip the `Display` piping and just go straight into a new string.
 
-Regarding formatting, there is one gotcha regarding the formatting of `Roman` values created via `Roman::new_unchecked()`: values that are less than the minimum printable value will come out as empty strings, while values that are larger will simply look like `MMMMMMMMMMMMMMMXIV` or something like that.
+Regarding formatting, there is one gotcha regarding the formatting of `Roman` values created via `Roman::new_unchecked()`: values that are larger will simply look like `MMMMMMMMMMMMMMMXIV` or something like that.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let seventeen: Roman = "XVII".parse().unwrap();
 
 There are several formatting options. `Roman` implements `Display`, which means that it'll work fine with `println!("{}")` et al., but for maximum efficiency (stop laughing!) I also provide two other functions: `to_lowercase()` and `to_uppercase()`. These skip the `Display` piping and just go straight into a new string.
 
-Regarding formatting, there is one gotcha regarding the formatting of `Roman` values created via `Roman::new_unchecked()`: values that are larger will simply look like `MMMMMMMMMMMMMMMXIV` or something like that.
+Regarding formatting, there is one gotcha regarding the formatting of `Roman` values created via `Roman::new_unchecked()`: values that are larger than `4999` will simply look like `MMMMMMMMMMMMMMMXIV` or something like that.
 
 ## Changelog
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     InvalidDigit(u8),
 
     /// Value out of range.
-    OutOfRange(i32),
+    OutOfRange(u16),
 }
 
 impl Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,13 +4,16 @@ use std::{
 };
 
 /// An error in parsing a Roman numeral.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Error {
     /// Encountered an invalid digit while parsing.
     InvalidDigit(u8),
 
     /// Value out of range.
     OutOfRange(u16),
+
+    /// Value is way out of range (> 65536).
+    Overflow,
 }
 
 impl Display for Error {
@@ -20,6 +23,7 @@ impl Display for Error {
                 write!(f, "Parser encountered an invalid digit: {}", *digit as char)
             }
             Error::OutOfRange(value) => write!(f, "Value out of range: {}", value),
+            Error::Overflow => f.write_str("Value out of range"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,11 @@
 //! ```rust
 //! # use xvii::Roman;
 //! let seventeen: Roman = "XVII".parse().unwrap();
-//! assert_eq!(17, seventeen.get());
+//! assert_eq!(17, seventeen.value());
 //! assert_eq!("XVII", seventeen.to_string());
 //!
 //! let seventeen = Roman::new(17).unwrap();
-//! assert_eq!(17, seventeen.get());
+//! assert_eq!(17, seventeen.value());
 //! assert_eq!("XVII", seventeen.to_string());
 //! ```
 #![deny(

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -5,7 +5,7 @@ use std::{fmt::{self, Display}, num::NonZeroU16, str::FromStr};
 
 /// A Roman numeral.
 ///
-/// This struct stores the value of a numeral as an [`u16`] but provides
+/// This struct stores the value of a numeral as an [`NonZeroU16`] but provides
 /// for Roman-style formatting.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Roman(NonZeroU16);
@@ -14,7 +14,7 @@ impl Roman {
     /// Creates a `Roman` value based on a [`u16`].
     ///
     /// This function will return `None` if the value supplied is outside the
-    /// acceptable range of `1...4999`, because numbers outside that range
+    /// acceptable range of `1..=4999`, because numbers outside that range
     /// cannot be appropriately formatted using the seven standard numerals.
     pub fn new(n: u16) -> Option<Roman> {
         match n {
@@ -85,12 +85,26 @@ impl Roman {
         }
     }
 
-    /// Returns the inner value.
-    pub fn get(self) -> u16 {
+    /// Returns value of this `Roman` numeral.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// let roman = xvii::Roman::new(42).unwrap();
+    /// assert_eq!(roman.value(), 42);
+    /// ```
+    pub fn value(self) -> u16 {
         self.0.get()
     }
 
     /// Returns the inner value.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// let roman = xvii::Roman::new(42).unwrap();
+    /// assert_eq!(roman.into_inner(), std::num::NonZeroU16::new(42).unwrap());
+    /// ```
     pub fn into_inner(self) -> NonZeroU16 {
         self.0
     }
@@ -179,6 +193,6 @@ mod tests {
     #[test]
     fn mmmmcmxcix_parses_as_4999() {
         let result: Roman = "MMMMCMXCIX".parse().unwrap();
-        assert_eq!(4999, result.get());
+        assert_eq!(4999, result.value());
     }
 }

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -1,17 +1,14 @@
 mod ladder;
 
 use crate::{unit::RomanUnitIterator, Error, Result};
-use std::{
-    fmt::{self, Display},
-    str::FromStr,
-};
+use std::{fmt::{self, Display}, num::NonZeroU16, str::FromStr};
 
 /// A Roman numeral.
 ///
 /// This struct stores the value of a numeral as an [`u16`] but provides
 /// for Roman-style formatting.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Roman(u16);
+pub struct Roman(NonZeroU16);
 
 impl Roman {
     /// Creates a `Roman` value based on a [`u16`].
@@ -21,7 +18,7 @@ impl Roman {
     /// cannot be appropriately formatted using the seven standard numerals.
     pub fn new(n: u16) -> Option<Roman> {
         match n {
-            n @ 1..=4999 => Some(Roman(n)),
+            n if n <= 4999 => NonZeroU16::new(n).map(Roman),
             _ => None,
         }
     }
@@ -35,7 +32,7 @@ impl Roman {
     /// assert_eq!(Roman::new(42).unwrap().to_uppercase(), "XLII");
     /// ```
     pub fn to_uppercase(self) -> String {
-        let mut current = self.0;
+        let mut current = self.0.get();
         let mut buf = String::new();
 
         for entry in ladder::VALUES {
@@ -57,7 +54,7 @@ impl Roman {
     /// assert_eq!(Roman::new(42).unwrap().to_lowercase(), "xlii");
     /// ```
     pub fn to_lowercase(self) -> String {
-        let mut current = self.0;
+        let mut current = self.0.get();
         let mut buf = String::new();
 
         for entry in ladder::VALUES {
@@ -90,6 +87,11 @@ impl Roman {
 
     /// Returns the inner value.
     pub fn get(self) -> u16 {
+        self.0.get()
+    }
+
+    /// Returns the inner value.
+    pub fn into_inner(self) -> NonZeroU16 {
         self.0
     }
 }
@@ -109,12 +111,12 @@ pub enum Style {
 #[derive(Debug, Copy, Clone)]
 pub struct RomanFormatter {
     style: Style,
-    value: u16,
+    value: NonZeroU16,
 }
 
 impl Display for RomanFormatter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut current = self.value;
+        let mut current = self.value.get();
 
         for entry in ladder::VALUES {
             while current >= entry.value {
@@ -134,10 +136,8 @@ impl FromStr for Roman {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        match RomanUnitIterator::new(s).sum::<Result<i32>>()? {
-            sum @ 1..=4999 => Ok(Roman(sum as u16)),
-            sum => Err(Error::OutOfRange(sum)),
-        }
+        let sum = RomanUnitIterator::new(s).sum::<Result<u16>>()?;
+        Roman::new(sum).ok_or(Error::OutOfRange(sum))
     }
 }
 
@@ -153,27 +153,27 @@ mod tests {
 
     #[test]
     fn mcmlxxxiv_equals_1984() {
-        assert_eq!("MCMLXXXIV", Roman(1984).to_string());
+        assert_eq!("MCMLXXXIV", Roman::new(1984).unwrap().to_string());
     }
 
     #[test]
     fn mmdxxix_equals_2529() {
-        assert_eq!("MMDXXIX", Roman(2529).to_string());
+        assert_eq!("MMDXXIX", Roman::new(2529).unwrap().to_string());
     }
 
     #[test]
     fn mmcmxcix_equals_2999() {
-        assert_eq!("MMCMXCIX", Roman(2999).to_string());
+        assert_eq!("MMCMXCIX", Roman::new(2999).unwrap().to_string());
     }
 
     #[test]
     fn mmmcmxcix_value_equals_3999() {
-        assert_eq!("MMMCMXCIX", Roman(3999).to_string());
+        assert_eq!("MMMCMXCIX", Roman::new(3999).unwrap().to_string());
     }
 
     #[test]
     fn max_value_equals_4999() {
-        assert_eq!("MMMMCMXCIX", Roman(4999).to_string());
+        assert_eq!("MMMMCMXCIX", Roman::new(4999).unwrap().to_string());
     }
 
     #[test]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -8,16 +8,16 @@ use std::str;
 /// multiplying these two.
 #[derive(Default)]
 struct Accumulator {
-    qty: i32,
-    val: i32,
+    qty: u16,
+    val: u16,
 }
 
 impl Accumulator {
-    fn new(val: i32) -> Self {
+    fn new(val: u16) -> Self {
         Accumulator { qty: 1, val }
     }
 
-    fn push(mut self, val: i32) -> PushResult {
+    fn push(mut self, val: u16) -> PushResult {
         use std::cmp::Ordering::*;
 
         match self.val.cmp(&val) {
@@ -31,7 +31,7 @@ impl Accumulator {
         }
     }
 
-    fn value(&self) -> i32 {
+    fn value(&self) -> u16 {
         self.qty * self.val
     }
 }
@@ -45,7 +45,7 @@ impl Accumulator {
 /// produced by the iterator and a new accumulator created.
 enum PushResult {
     Partial(Accumulator),
-    Complete(i32, Option<Accumulator>),
+    Complete(u16, Option<Accumulator>),
 }
 
 /// Iterates "units" of a Roman numeral.
@@ -70,7 +70,7 @@ impl<'a> RomanUnitIterator<'a> {
 }
 
 impl<'a> Iterator for RomanUnitIterator<'a> {
-    type Item = Result<i32>;
+    type Item = Result<u16>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -96,7 +96,7 @@ impl<'a> Iterator for RomanUnitIterator<'a> {
     }
 }
 
-fn to_digit(u: u8) -> Result<i32> {
+fn to_digit(u: u8) -> Result<u16> {
     match u.to_ascii_lowercase() {
         b'm' => Ok(1000),
         b'd' => Ok(500),

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -126,8 +126,8 @@ mod tests {
 
     #[test]
     fn i_equals_1() {
-        assert_eq!(1, "i".parse::<Roman>().unwrap().get());
-        assert_eq!(1, "I".parse::<Roman>().unwrap().get());
+        assert_eq!(1, "i".parse::<Roman>().unwrap().value());
+        assert_eq!(1, "I".parse::<Roman>().unwrap().value());
     }
 
     #[test]
@@ -138,12 +138,12 @@ mod tests {
 
     #[test]
     fn ix_equals_9() {
-        assert_eq!(9, "ix".parse::<Roman>().unwrap().get());
+        assert_eq!(9, "ix".parse::<Roman>().unwrap().value());
     }
 
     #[test]
     fn iiiiix_equals_5() {
         // Yes, I know this is stupid, but this is how units are meant to work.
-        assert_eq!(5, "iiiiix".parse::<Roman>().unwrap().get());
+        assert_eq!(5, "iiiiix".parse::<Roman>().unwrap().value());
     }
 }


### PR DESCRIPTION
This will remove one 'illegal' state from `Roman` - `Roman(0)`.
Also this allows compiler to make niche-optimizations.

Sidenote: maybe we shoud add `value: Roman -> u16` method? Using `.into_inner().get()` feels noisy...

Fixes #8 