### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # XVII
 
 [![Crates.io](https://img.shields.io/crates/v/xvii.svg)](https://crates.io/crates/xvii)
+[![documentation (docs.rs)](https://docs.rs/xvii/badge.svg)](https://docs.rs/xvii)
 [![Build Status](https://travis-ci.org/archer884/xvii.svg?branch=master)](https://travis-ci.org/archer884/xvii)
 
 ...Pronounced any way you like, including "seventeen."

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
-use std::error;
-use std::fmt::{self, Display};
+use std::{
+    error,
+    fmt::{self, Display},
+};
 
-#[derive(Debug)]
 /// An error in parsing a Roman numeral.
+#[derive(Debug)]
 pub enum Error {
     /// Encountered an invalid digit while parsing.
     InvalidDigit(u8),
@@ -14,12 +16,10 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::InvalidDigit(digit) => write!(
-                f,
-                "{}: {}",
-                "Parser encountered an invalid digit", *digit as char
-            ),
-            Error::OutOfRange(value) => write!(f, "{}: {}", "Value out of range", value),
+            Error::InvalidDigit(digit) => {
+                write!(f, "Parser encountered an invalid digit: {}", *digit as char)
+            }
+            Error::OutOfRange(value) => write!(f, "Value out of range: {}", value),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,19 @@
 //! assert_eq!(17, seventeen.into_inner());
 //! assert_eq!("XVII", seventeen.to_string());
 //! ```
+#![deny(
+    unsafe_code,
+    missing_docs,
+    missing_debug_implementations,
+    broken_intra_doc_links
+)]
 
 mod error;
 mod roman;
 mod unit;
 
 pub use error::Error;
-pub use roman::Roman;
+pub use roman::{Roman, RomanFormatter, Style};
 
+/// [`Result`](std::result::Result) with error defaulted to [`xvii::Error`](Error)
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -1,6 +1,161 @@
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
 use crate::{unit::RomanUnitIterator, Error, Result};
-use std::fmt::{self, Display};
-use std::str::FromStr;
+
+/// A Roman numeral.
+///
+/// This struct stores the value of a numeral as an [`u16`] but provides
+/// for Roman-style formatting.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Roman(u16);
+
+impl Roman {
+    /// Creates a `Roman` value based on a [`u16`].
+    ///
+    /// This function will return `None` if the value supplied is outside the
+    /// acceptable range of `1...4999`, because numbers outside that range
+    /// cannot be appropriately formatted using the seven standard numerals.
+    pub fn new(n: u16) -> Option<Roman> {
+        match n {
+            n @ 1..=4999 => Some(Roman(n)),
+            _ => None,
+        }
+    }
+
+    /// Creates a [`Roman`] value based on a [`u16`].
+    ///
+    /// This function will return any [`u16`] wrapped in a `Roman` newtype
+    /// without bothering to check its range, regardless of how unprintable
+    /// it is.
+    ///
+    /// > Note: being "unprintable" is not memory unsafe and will not panic.
+    pub fn new_unchecked(n: u16) -> Roman {
+        Roman(n)
+    }
+
+    /// Formats a [`Roman`] value as an uppercase Roman numeral.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use xvii::Roman;
+    /// assert_eq!(Roman::new(42).unwrap().to_uppercase(), "XLII");
+    /// ```
+    pub fn to_uppercase(self) -> String {
+        let mut current = self.0;
+        let mut buf = String::new();
+
+        for entry in LADDER {
+            while current >= entry.value {
+                current -= entry.value;
+                buf += entry.upper;
+            }
+        }
+
+        buf
+    }
+
+    /// Formats a [`Roman`] value as a lowercase Roman numeral.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use xvii::Roman;
+    /// assert_eq!(Roman::new(42).unwrap().to_lowercase(), "xlii");
+    /// ```
+    pub fn to_lowercase(self) -> String {
+        let mut current = self.0;
+        let mut buf = String::new();
+
+        for entry in LADDER {
+            while current >= entry.value {
+                current -= entry.value;
+                buf += entry.lower;
+            }
+        }
+
+        buf
+    }
+
+    /// Returns a [`RomanFormatter`] which lazily formats a `self` value as a lowercase or uppercase Roman numeral depending of `style`.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use xvii::{Roman, Style};
+    ///
+    /// let value = Roman::new(12).unwrap();
+    /// assert_eq!(format!("{}", value.format(Style::Upper)), "XII");
+    /// assert_eq!(value.format(Style::Lower).to_string(), "xii"); // `format!("{}")` and `.to_string()` are the same thing
+    /// ```
+    pub fn format(&self, style: Style) -> RomanFormatter {
+        RomanFormatter {
+            style,
+            value: self.0,
+        }
+    }
+
+    /// Returns the inner value.
+    pub fn into_inner(self) -> u16 {
+        self.0
+    }
+}
+
+/// Style of formatting — lowercase or uppercase.
+#[derive(Debug, Copy, Clone)]
+pub enum Style {
+    /// Lowercase formatting. E.g.: `xvii`.
+    Lower,
+    /// Uppercase formatting. E.g.: `XVII`.
+    Upper,
+}
+
+/// Lazy roman formatter.
+///
+/// This struct is created by [`format`] method.
+#[derive(Debug, Copy, Clone)]
+pub struct RomanFormatter {
+    style: Style,
+    value: u16,
+}
+
+impl Display for RomanFormatter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut current = self.value;
+
+        for entry in LADDER {
+            while current >= entry.value {
+                match self.style {
+                    Style::Lower => f.write_str(entry.lower)?,
+                    Style::Upper => f.write_str(entry.upper)?,
+                }
+                current -= entry.value;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for Roman {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match RomanUnitIterator::new(s).sum::<Result<i32>>()? {
+            sum @ 1..=4999 => Ok(Roman::new_unchecked(sum as u16)),
+            sum => Err(Error::OutOfRange(sum)),
+        }
+    }
+}
+
+impl Display for Roman {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.format(Style::Upper).fmt(f)
+    }
+}
 
 struct LadderEntry {
     upper: &'static str,
@@ -75,126 +230,6 @@ static LADDER: &[LadderEntry] = &[
         value: 1,
     },
 ];
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-/// A Roman numeral.
-///
-/// This struct stores the value of a numeral as an `u16` but provides
-/// for Roman-style formatting.
-pub struct Roman(u16);
-
-impl Roman {
-    /// Creates a `Roman` value based on a `u16`.
-    ///
-    /// This function will return `None` if the value supplied is outside the
-    /// acceptable range of `1...4999`, because numbers outside that range
-    /// cannot be appropriately formatted using the seven standard numerals.
-    pub fn new(n: u16) -> Option<Roman> {
-        match n {
-            n @ 1..=4999 => Some(Roman(n)),
-            _ => None,
-        }
-    }
-
-    /// Creates a `Roman` value based on a `u16`.
-    ///
-    /// This function will return any `u16` wrapped in a `Roman` newtype
-    /// without bothering to check its range, regardless of how unprintable
-    /// it is.
-    ///
-    /// > Note: being "unprintable" is not memory unsafe and will not panic.
-    pub fn new_unchecked(n: u16) -> Roman {
-        Roman(n)
-    }
-
-    /// Formats a `Roman` value as an uppercase Roman numeral.
-    pub fn to_uppercase(self) -> String {
-        let mut current = self.0;
-        let mut buf = String::new();
-
-        for entry in LADDER {
-            while current >= entry.value {
-                current -= entry.value;
-                buf += entry.upper;
-            }
-        }
-
-        buf
-    }
-
-    /// Formats a `Roman` value as a lowercase Roman numeral.
-    pub fn to_lowercase(self) -> String {
-        let mut current = self.0;
-        let mut buf = String::new();
-
-        for entry in LADDER {
-            while current >= entry.value {
-                current -= entry.value;
-                buf += entry.lower;
-            }
-        }
-
-        buf
-    }
-
-    pub fn format(&self, style: Style) -> RomanFormatter {
-        RomanFormatter {
-            style,
-            value: self.0,
-        }
-    }
-
-    pub fn into_inner(self) -> u16 {
-        self.0
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum Style {
-    Lower,
-    Upper,
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct RomanFormatter {
-    style: Style,
-    value: u16,
-}
-
-impl Display for RomanFormatter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut current = self.value;
-
-        for entry in LADDER {
-            while current >= entry.value {
-                match self.style {
-                    Style::Lower => f.write_str(entry.lower)?,
-                    Style::Upper => f.write_str(entry.upper)?,
-                }
-                current -= entry.value;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl FromStr for Roman {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match RomanUnitIterator::new(s).sum::<Result<i32>>()? {
-            sum @ 1..=4999 => Ok(Roman::new_unchecked(sum as u16)),
-            sum => Err(Error::OutOfRange(sum)),
-        }
-    }
-}
-
-impl Display for Roman {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format(Style::Upper))
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,9 +1,10 @@
-use crate::{Error, Result};
 use std::str;
 
-/// Accumulates the value of a single numeral "unit."
+use crate::{Error, Result};
+
+/// Accumulates the value of a single numeral "unit".
 ///
-/// qty represents the number of times the numeral has appeared in the unit, while num represents
+/// `qty` represents the number of times the numeral has appeared in the unit, while `num` represents
 /// the numeric value of the numeral. Obviously, the final value of the unit is evaluated by
 /// multiplying these two.
 #[derive(Default)]
@@ -39,7 +40,7 @@ impl Accumulator {
 /// The result of a push onto an accumulator.
 ///
 /// Adding an additional instance of the original unit onto an accumulator emits a partial result
-/// because the accumulator may have an indefinite number of such instances. I, II, III, IIIIIII
+/// because the accumulator may have an indefinite number of such instances. `I`, `II`, `III`, `IIIIIII`
 /// and so forth are all valid contents for an accumulator. However, changing the unit value
 /// will cause the accumulator to emit a complete result, signifying that a value should be
 /// produced by the iterator and a new accumulator created.
@@ -97,7 +98,7 @@ impl<'a> Iterator for RomanUnitIterator<'a> {
 }
 
 fn to_digit(u: u8) -> Result<i32> {
-    match u | 32 {
+    match u.to_ascii_lowercase() {
         b'm' => Ok(1000),
         b'd' => Ok(500),
         b'c' => Ok(100),


### PR DESCRIPTION
- Make formatting consisntent
- Add docs & doc tests
- Add doc links
- Deny use of unsafe code, missing/broken docs and missing debug impls
- Reexport `RomanFormatter` and `Style` (before this, `Roman::format` method was uncallible)
- Remove/simplify use of `write!` macro
- Use `to_ascii_lowercase` instead of `| 32` (this makes code more readable)
- Fmt
