### PR TITLE
`no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ Library for parsing or printing Roman numerals
 
 [features]
 std = []
+
+[package.metadata."docs.rs"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ Library for parsing or printing Roman numerals
 """
 
 [features]
+default = ["std"]
 std = []
 
 [package.metadata."docs.rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ keywords = ["roman", "numeral", "xvii", "seventeen"]
 description = """
 Library for parsing or printing Roman numerals
 """
+
+[features]
+std = []

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This library provides parsing and formatting for Roman numerals. According to my
 
 Also, if you have a high-availability NAAS project, you need to have your head examined. I don't know if that was clear when I originally wrote this readme, so I'm adding it now.
 
+_Compiler support: requires rustc 1.47+_
+
 ## Usage
 
 ### Parsing

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,4 @@
-use std::{
-    error,
-    fmt::{self, Display},
-};
+use core::fmt::{self, Display};
 
 /// An error in parsing a Roman numeral.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -28,4 +25,5 @@ impl Display for Error {
     }
 }
 
-impl error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,18 @@
 //! assert_eq!(17, seventeen.value());
 //! assert_eq!("XVII", seventeen.to_string());
 //! ```
+//!
+//! # `no_std` support
+//!
+//! No-std mode is supported, **unless** `std` crate feature is enabled
+//!
+//! ```toml
+//! xvii = { version = "...", features = ["std"] }
+//! ```
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+// To build docs properly, run
+// `RUSTFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     unsafe_code,
     missing_docs,
@@ -35,4 +47,4 @@ pub use error::Error;
 pub use roman::{Roman, RomanFormatter, Style};
 
 /// [`Result`](std::result::Result) with error defaulted to [`xvii::Error`](Error)
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,11 @@
 //!
 //! # `no_std` support
 //!
-//! No-std mode is supported, **unless** `std` crate feature is enabled
+//! `no_std` mode is supported if crate is built without `std` feature (enabled by default).
+//! I.e. you need to turn off default features to build `xvii` without std:
 //!
 //! ```toml
-//! xvii = { version = "...", features = ["std"] }
+//! xvii = { version = "...", default-features = false }
 //! ```
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 // To build docs properly, run

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -20,9 +20,12 @@ impl Roman {
     /// This function will return `None` if the value supplied is outside the
     /// acceptable range of `1..=4999`, because numbers outside that range
     /// cannot be appropriately formatted using the seven standard numerals.
-    pub fn new(n: u16) -> Option<Roman> {
+    pub const fn new(n: u16) -> Option<Roman> {
         match n {
-            n if n <= 4999 => NonZeroU16::new(n).map(Roman),
+            n if n <= 4999 => match NonZeroU16::new(n) {
+                Some(inner) => Some(Self(inner)),
+                None => None,
+            },
             _ => None,
         }
     }
@@ -86,7 +89,7 @@ impl Roman {
     /// assert_eq!(format!("{}", value.format(Style::Upper)), "XII");
     /// assert_eq!(value.format(Style::Lower).to_string(), "xii"); // `format!("{}")` and `.to_string()` are the same thing
     /// ```
-    pub fn format(&self, style: Style) -> RomanFormatter {
+    pub const fn format(&self, style: Style) -> RomanFormatter {
         RomanFormatter {
             style,
             value: self.0,
@@ -101,7 +104,7 @@ impl Roman {
     /// let roman = xvii::Roman::new(42).unwrap();
     /// assert_eq!(roman.value(), 42);
     /// ```
-    pub fn value(self) -> u16 {
+    pub const fn value(self) -> u16 {
         self.0.get()
     }
 
@@ -113,7 +116,7 @@ impl Roman {
     /// let roman = xvii::Roman::new(42).unwrap();
     /// assert_eq!(roman.into_inner(), std::num::NonZeroU16::new(42).unwrap());
     /// ```
-    pub fn into_inner(self) -> NonZeroU16 {
+    pub const fn into_inner(self) -> NonZeroU16 {
         self.0
     }
 }

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -1,7 +1,7 @@
 mod ladder;
 
 use crate::{unit::RomanUnitIterator, Error, Result};
-use std::{
+use core::{
     fmt::{self, Display},
     num::NonZeroU16,
     str::FromStr,
@@ -35,6 +35,8 @@ impl Roman {
     /// use xvii::Roman;
     /// assert_eq!(Roman::new(42).unwrap().to_uppercase(), "XLII");
     /// ```
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn to_uppercase(self) -> String {
         let mut current = self.0.get();
         let mut buf = String::new();
@@ -57,6 +59,8 @@ impl Roman {
     /// use xvii::Roman;
     /// assert_eq!(Roman::new(42).unwrap().to_lowercase(), "xlii");
     /// ```
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn to_lowercase(self) -> String {
         let mut current = self.0.get();
         let mut buf = String::new();
@@ -125,7 +129,7 @@ pub enum Style {
 
 /// Lazy roman formatter.
 ///
-/// This struct is created by [`format`] method.
+/// This struct is created by [`format`](Roman::format) method.
 #[derive(Debug, Copy, Clone)]
 pub struct RomanFormatter {
     style: Style,

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -33,7 +33,7 @@ impl Accumulator {
         Some(res)
     }
 
-    fn value(&self) -> Option<u16> {
+    const fn value(&self) -> Option<u16> {
         self.qty.checked_mul(self.val)
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Result};
-use std::str;
+use core::str;
 
 /// Accumulates the value of a single numeral "unit".
 ///
@@ -18,7 +18,7 @@ impl Accumulator {
     }
 
     fn push(mut self, val: u16) -> Option<PushResult> {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
 
         let res = match self.val.cmp(&val) {
             Equal => {


### PR DESCRIPTION
- `no_std` support
- add `const` to some functions
- add msrv note to readme

Fixes #9 