### PR TITLE
New returns xvii::Result<Roman>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "xvii"
-# Do not forget bump the version before release. There were breaking changes.
-version = "0.4.0"
+version = "0.4.1"
 authors = ["J/A <archer884@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,10 @@
 // `RUSTFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
-    unsafe_code,
-    missing_docs,
+    broken_intra_doc_links,
     missing_debug_implementations,
-    broken_intra_doc_links
+    missing_docs,
+    unsafe_code
 )]
 
 mod error;

--- a/src/roman.rs
+++ b/src/roman.rs
@@ -20,13 +20,10 @@ impl Roman {
     /// This function will return `None` if the value supplied is outside the
     /// acceptable range of `1..=4999`, because numbers outside that range
     /// cannot be appropriately formatted using the seven standard numerals.
-    pub const fn new(n: u16) -> Option<Roman> {
-        match n {
-            n if n <= 4999 => match NonZeroU16::new(n) {
-                Some(inner) => Some(Self(inner)),
-                None => None,
-            },
-            _ => None,
+    pub fn new(n: u16) -> Result<Roman> {
+        match NonZeroU16::new(n) {
+            Some(n) if n.get() <= 4999 => Ok(Roman(n)),
+            _ => Err(Error::OutOfRange(n)),
         }
     }
 
@@ -163,7 +160,7 @@ impl FromStr for Roman {
     fn from_str(s: &str) -> Result<Self> {
         let sum = RomanUnitIterator::new(s)
             .try_fold(0, |acc, r| r?.checked_add(acc).ok_or(Error::Overflow))?;
-        Roman::new(sum).ok_or(Error::OutOfRange(sum))
+        Roman::new(sum)
     }
 }
 


### PR DESCRIPTION
Back when this library was created, the idea of using a Result type as a return type for main wasn't a thing yet. As a result (badum tsh!), I have submitted this PR to improve compliance with modern conventions.